### PR TITLE
Replaced references to "BabyNames" with "DummyProducts" in the dp tests

### DIFF
--- a/IRShowcaseMVPTests/DataProvider/DataProviderLocalOnErrorUseRemoteTests.swift
+++ b/IRShowcaseMVPTests/DataProvider/DataProviderLocalOnErrorUseRemoteTests.swift
@@ -17,13 +17,13 @@ import Combine
 class DataProviderLocalOnErrorRemoteTests: QuickSpec {
     override class func spec() {
         describe("DataProvidersTests") {
-            var dataProvider: DataProvider<BabyNamePopularityDataContainer>!
+            var dataProvider: DataProvider<DummyProductDataContainer>!
             let network = APIServiceMock()
             let persistence = PersistenceLayerMock()
             var cancellables: Set<AnyCancellable>!
 
             beforeEach {
-                let dp: DataProvider<BabyNamePopularityDataContainer> = DataProviderBuilder.makeDataProvider(
+                let dp: DataProvider<DummyProductDataContainer> = DataProviderBuilder.makeDataProvider(
                     config: DataProviderConfiguration.localOnErrorUseRemote,
                     network: network,
                     persistence: persistence
@@ -40,11 +40,11 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
             describe("local and on error use remote data provider") {
                 context("fetch stuff method") {
                     it("should get a success result on the happy path") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
-                        
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+
                         Given(persistence, .fetchResource(.any, willReturn: {
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
-                            let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(babyNamePopularities)
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
+                            let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(dataContainer)
                             return publisher.eraseToAnyPublisher()
                         }()
                         ))
@@ -52,10 +52,10 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -72,7 +72,7 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -81,7 +81,7 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
                                         fail()
                                     }
                                 } receiveValue: { values in
-                                    expect(values.0.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                    expect(values.0.products.count).to(beGreaterThan(0))
                                     done()
                                 }
                                 .store(in: &cancellables)
@@ -89,10 +89,10 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
                     }
 
                     it("should error if both layers returns an error and/or invalid data") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(.any, willReturn: {
-                            let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
+                            let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
                             publisher.send(completion: .failure(PersistenceLayerError.persistence(error: NSError.error(withMessage: "Error"))))
                             return publisher.eraseToAnyPublisher()
                         }()
@@ -106,7 +106,7 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -122,11 +122,11 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
                     }
 
                     it("should get persisted posts even if parsing step after network fails") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(.any, willReturn: {
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
-                            let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(babyNamePopularities)
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
+                            let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(dataContainer)
                             return publisher.eraseToAnyPublisher()
                         }()
                         ))
@@ -140,7 +140,7 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -149,7 +149,7 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
                                         fail()
                                     }
                                 } receiveValue: { values in
-                                    expect(values.0.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                    expect(values.0.products.count).to(beGreaterThan(0))
                                     done()
                                 }
                                 .store(in: &cancellables)
@@ -157,12 +157,12 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
                     }
 
                     it("should get network posts if theres was an error on the persistence layer") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
                                 publisher.send(completion: .failure(PersistenceLayerError.persistence(error: NSError.error(withMessage: "Error"))))
                                 return publisher.eraseToAnyPublisher()
                             }()
@@ -171,10 +171,10 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -190,7 +190,7 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -199,7 +199,7 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
                                         fail()
                                     }
                                 } receiveValue: { values in
-                                    expect(values.0.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                    expect(values.0.products.count).to(beGreaterThan(0))
                                     done()
                                 }
                                 .store(in: &cancellables)
@@ -207,12 +207,12 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
                     }
 
                     it("should succeed if nothing (empty array) is returned from the persistence layer") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
                                 return publisher.eraseToAnyPublisher()
                             }()
                         ))
@@ -220,10 +220,10 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -239,7 +239,7 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -252,7 +252,7 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
 
                                     switch source {
                                     case .local:
-                                        expect(value.babyNamePopularityRepresentation.count).to(equal(0))
+                                        expect(value.products.count).to(equal(0))
                                         done()
                                     case .remote:
                                         fail()
@@ -264,5 +264,16 @@ class DataProviderLocalOnErrorRemoteTests: QuickSpec {
                 }
             }
         }
+    }
+}
+
+private extension DummyProductDataContainer {
+    static func stub() -> DummyProductDataContainer {
+        .init(
+            total: 0,
+            skip: 0,
+            limit: 0,
+            products: []
+        )
     }
 }

--- a/IRShowcaseMVPTests/DataProvider/DataProviderLocalThenRemoteTests.swift
+++ b/IRShowcaseMVPTests/DataProvider/DataProviderLocalThenRemoteTests.swift
@@ -17,13 +17,13 @@ import Combine
 class DataProviderLocalThenRemoteTests: QuickSpec {
     override class func spec() {
         describe("DataProvidersTests") {
-            var dataProvider: DataProvider<BabyNamePopularityDataContainer>!
+            var dataProvider: DataProvider<DummyProductDataContainer>!
             let network = APIServiceMock()
             let persistence = PersistenceLayerMock()
             var cancellables: Set<AnyCancellable>!
 
             beforeEach {
-                let dp: DataProvider<BabyNamePopularityDataContainer> = DataProviderBuilder.makeDataProvider(
+                let dp: DataProvider<DummyProductDataContainer> = DataProviderBuilder.makeDataProvider(
                     config: DataProviderConfiguration.localFirstThenRemote,
                     network: network,
                     persistence: persistence
@@ -40,11 +40,11 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
             describe("local first then remote data provider") {
                 context("fetch stuff method") {
                     it("should get a success result (value) from both layers on the happy path") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
-                        
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+
                         Given(persistence, .fetchResource(.any, willReturn: {
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
-                            let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(babyNamePopularities)
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
+                            let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(dataContainer)
                             return publisher.eraseToAnyPublisher()
                         }()
                         ))
@@ -52,10 +52,10 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -74,7 +74,7 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                             var invocationsCount = 0;
                             
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -87,9 +87,9 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
 
                                     switch source {
                                     case .local:
-                                        expect(value.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                        expect(value.products.count).to(beGreaterThan(0))
                                     case .remote:
-                                        expect(value.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                        expect(value.products.count).to(beGreaterThan(0))
                                     }
 
                                     invocationsCount += 1;
@@ -102,10 +102,10 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                     }
 
                     it("should error if both layers returns an error and/or invalid data") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(.any, willReturn: {
-                            let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
+                            let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
                             publisher.send(completion: .failure(PersistenceLayerError.persistence(error: NSError.error(withMessage: "Error"))))
                             return publisher.eraseToAnyPublisher()
                         }()
@@ -119,7 +119,7 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -135,11 +135,11 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                     }
 
                     it("should get persisted posts even if parsing step after network fails") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(.any, willReturn: {
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
-                            let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(babyNamePopularities)
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
+                            let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(dataContainer)
                             return publisher.eraseToAnyPublisher()
                         }()
                         ))
@@ -153,7 +153,7 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -162,7 +162,7 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                                         fail()
                                     }
                                 } receiveValue: { values in
-                                    expect(values.0.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                    expect(values.0.products.count).to(beGreaterThan(0))
                                     done()
                                 }
                                 .store(in: &cancellables)
@@ -170,12 +170,12 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                     }
 
                     it("should get network posts if theres was an error on the persistence layer") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
                                 publisher.send(completion: .failure(PersistenceLayerError.persistence(error: NSError.error(withMessage: "Error"))))
                                 return publisher.eraseToAnyPublisher()
                             }()
@@ -184,10 +184,10 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -203,7 +203,7 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -212,7 +212,7 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                                         fail()
                                     }
                                 } receiveValue: { values in
-                                    expect(values.0.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                    expect(values.0.products.count).to(beGreaterThan(0))
                                     done()
                                 }
                                 .store(in: &cancellables)
@@ -220,12 +220,12 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                     }
 
                     it("should receive values from both layers even if nothing (empty array) is returned from the persistence layer") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
                                 return publisher.eraseToAnyPublisher()
                             }()
                         ))
@@ -233,10 +233,10 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -254,7 +254,7 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                             var invocationsCount = 0;
 
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -267,9 +267,9 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
 
                                     switch source {
                                     case .local:
-                                        expect(value.babyNamePopularityRepresentation.count).to(equal(0))
+                                        expect(value.products.count).to(equal(0))
                                     case .remote:
-                                        expect(value.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                        expect(value.products.count).to(beGreaterThan(0))
                                     }
 
                                     invocationsCount += 1;
@@ -283,5 +283,16 @@ class DataProviderLocalThenRemoteTests: QuickSpec {
                 }
             }
         }
+    }
+}
+
+private extension DummyProductDataContainer {
+    static func stub() -> DummyProductDataContainer {
+        .init(
+            total: 0,
+            skip: 0,
+            limit: 0,
+            products: []
+        )
     }
 }

--- a/IRShowcaseMVPTests/DataProvider/DataProviderRemoteOnErrorUseLocalTests.swift
+++ b/IRShowcaseMVPTests/DataProvider/DataProviderRemoteOnErrorUseLocalTests.swift
@@ -17,13 +17,13 @@ import Combine
 class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
     override class func spec() {
         describe("DataProvidersTests") {
-            var dataProvider: DataProvider<BabyNamePopularityDataContainer>!
+            var dataProvider: DataProvider<DummyProductDataContainer>!
             let network = APIServiceMock()
             let persistence = PersistenceLayerMock()
             var cancellables: Set<AnyCancellable>!
 
             beforeEach {
-                let hrdp: DataProvider<BabyNamePopularityDataContainer> = DataProviderBuilder.makeDataProvider(
+                let hrdp: DataProvider<DummyProductDataContainer> = DataProviderBuilder.makeDataProvider(
                     config: DataProviderConfiguration.remoteOnErrorUseLocal,
                     network: network,
                     persistence: persistence
@@ -40,13 +40,13 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
             describe("remote and on error use local data provider") {
                 context("fetch stuff method") {
                     it("should get a success result on the happy path") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
-                        
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(babyNamePopularities)
+                                let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(dataContainer)
                                 return publisher.eraseToAnyPublisher()
                             }()
                         ))
@@ -54,10 +54,10 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -73,7 +73,7 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                         
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -82,7 +82,7 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                                         fail()
                                     }
                                 } receiveValue: { values in
-                                    expect(values.0.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                    expect(values.0.products.count).to(beGreaterThan(0))
                                     done()
                                 }
                                 .store(in: &cancellables)
@@ -90,12 +90,12 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                     }
 
                     it("should error if both layers returns an error and/or invalid data") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
                                 publisher.send(completion: .failure(PersistenceLayerError.persistence(error: NSError.error(withMessage: "Error"))))
                                 return publisher.eraseToAnyPublisher()
                             }()
@@ -110,7 +110,7 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -126,13 +126,13 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                     }
 
                     it("should get persisted posts even if parsing step after network fails") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(babyNamePopularities)
+                                let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(dataContainer)
                                 return publisher.eraseToAnyPublisher()
                             }()
                         ))
@@ -146,7 +146,7 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -155,7 +155,7 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                                         fail()
                                     }
                                 } receiveValue: { values in
-                                    expect(values.0.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                    expect(values.0.products.count).to(beGreaterThan(0))
                                     done()
                                 }
                                 .store(in: &cancellables)
@@ -163,12 +163,12 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                     }
 
                     it("should get network posts if theres was an error on the persistence layer") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
                                 publisher.send(completion: .failure(PersistenceLayerError.persistence(error: NSError.error(withMessage: "Error"))))
                                 return publisher.eraseToAnyPublisher()
                             }()
@@ -177,10 +177,10 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -196,7 +196,7 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -205,7 +205,7 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                                         fail()
                                     }
                                 } receiveValue: { values in
-                                    expect(values.0.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                    expect(values.0.products.count).to(beGreaterThan(0))
                                     done()
                                 }
                                 .store(in: &cancellables)
@@ -213,13 +213,13 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                     }
 
                     it("should succeed if nothing (empty array) is returned from the persistence layer") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
-                                publisher.send(.init(data: []))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
+                                publisher.send(.stub())
                                 return publisher.eraseToAnyPublisher()
                             }()
                         ))
@@ -227,10 +227,10 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -246,7 +246,7 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -261,7 +261,7 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                                     case .local:
                                         fail()
                                     case .remote:
-                                        expect(value.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                        expect(value.products.count).to(beGreaterThan(0))
                                         done()
                                     }
                                 }
@@ -271,5 +271,16 @@ class DataProviderRemoteOnErrorUseLocalTests: QuickSpec {
                 }
             }
         }
+    }
+}
+
+private extension DummyProductDataContainer {
+    static func stub() -> DummyProductDataContainer {
+        .init(
+            total: 0,
+            skip: 0,
+            limit: 0,
+            products: []
+        )
     }
 }

--- a/IRShowcaseMVPTests/DataProvider/DataProviderRemoteOnlyTests.swift
+++ b/IRShowcaseMVPTests/DataProvider/DataProviderRemoteOnlyTests.swift
@@ -17,14 +17,14 @@ import Combine
 class DataProviderRemoteOnlyTests: QuickSpec {
     override class func spec() {
         describe("DataProvidersTests") {
-            var remoteDataProvider: DataProvider<BabyNamePopularityDataContainer>!
+            var remoteDataProvider: DataProvider<DummyProductDataContainer>!
             let network = APIServiceMock()
             let persistence = PersistenceLayerMock()
             var cancellables: Set<AnyCancellable>!
 
             beforeEach {
                 let remoteConfig = DataProviderConfiguration.remoteOnly
-                let rdp: DataProvider<BabyNamePopularityDataContainer> = DataProviderBuilder.makeDataProvider(config: remoteConfig, network: network, persistence: persistence)
+                let rdp: DataProvider<DummyProductDataContainer> = DataProviderBuilder.makeDataProvider(config: remoteConfig, network: network, persistence: persistence)
                 remoteDataProvider = rdp
                 cancellables = Set<AnyCancellable>()
             }
@@ -37,15 +37,15 @@ class DataProviderRemoteOnlyTests: QuickSpec {
             describe("remote data provider") {
                 context("fetch stuff method") {
                     it("should get a success result on the happy path") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -61,7 +61,7 @@ class DataProviderRemoteOnlyTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             remoteDataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -70,7 +70,7 @@ class DataProviderRemoteOnlyTests: QuickSpec {
                                         fail()
                                     }
                                 } receiveValue: { values in
-                                    expect(values.0.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                    expect(values.0.products.count).to(beGreaterThan(0))
                                     done()
                                 }
                                 .store(in: &cancellables)
@@ -78,7 +78,7 @@ class DataProviderRemoteOnlyTests: QuickSpec {
                     }
 
                     it("should fail before the parsing step when receives generic/empty data") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
@@ -89,7 +89,7 @@ class DataProviderRemoteOnlyTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             remoteDataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:

--- a/IRShowcaseMVPTests/DataProvider/DataProviderRemoteThenLocalTests.swift
+++ b/IRShowcaseMVPTests/DataProvider/DataProviderRemoteThenLocalTests.swift
@@ -17,13 +17,13 @@ import Combine
 class DataProviderRemoteThenLocalTests: QuickSpec {
     override class func spec() {
         describe("DataProvidersTests") {
-            var dataProvider: DataProvider<BabyNamePopularityDataContainer>!
+            var dataProvider: DataProvider<DummyProductDataContainer>!
             let network = APIServiceMock()
             let persistence = PersistenceLayerMock()
             var cancellables: Set<AnyCancellable>!
 
             beforeEach {
-                let dp: DataProvider<BabyNamePopularityDataContainer> = DataProviderBuilder.makeDataProvider(
+                let dp: DataProvider<DummyProductDataContainer> = DataProviderBuilder.makeDataProvider(
                     config: DataProviderConfiguration.remoteFirstThenLocal,
                     network: network,
                     persistence: persistence
@@ -40,13 +40,13 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
             describe("remote first then local data provider") {
                 context("fetch stuff method") {
                     it("should get a success result (value) from both layers on the happy path") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
-                        
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(babyNamePopularities)
+                                let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(dataContainer)
                                 return publisher.eraseToAnyPublisher()
                             }()
                         ))
@@ -54,10 +54,10 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -75,7 +75,7 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                             var invocationsCount = 0
 
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -88,9 +88,9 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
 
                                     switch source {
                                     case .local:
-                                        expect(value.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                        expect(value.products.count).to(beGreaterThan(0))
                                     case .remote:
-                                        expect(value.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                        expect(value.products.count).to(beGreaterThan(0))
                                     }
 
                                     invocationsCount += 1;
@@ -103,12 +103,12 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                     }
 
                     it("should error if both layers returns an error and/or invalid data") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
                                 publisher.send(completion: .failure(PersistenceLayerError.persistence(error: NSError.error(withMessage: "Error"))))
                                 return publisher.eraseToAnyPublisher()
                             }()
@@ -123,7 +123,7 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -139,13 +139,13 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                     }
 
                     it("should get persisted posts even if parsing step after network fails") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(babyNamePopularities)
+                                let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(dataContainer)
                                 return publisher.eraseToAnyPublisher()
                             }()
                         ))
@@ -159,7 +159,7 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -168,7 +168,7 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                                         fail()
                                     }
                                 } receiveValue: { values in
-                                    expect(values.0.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                    expect(values.0.products.count).to(beGreaterThan(0))
                                     done()
                                 }
                                 .store(in: &cancellables)
@@ -176,12 +176,12 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                     }
 
                     it("should get network posts if theres was an error on the persistence layer") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
                                 publisher.send(completion: .failure(PersistenceLayerError.persistence(error: NSError.error(withMessage: "Error"))))
                                 return publisher.eraseToAnyPublisher()
                             }()
@@ -190,10 +190,10 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -209,7 +209,7 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
 
                         waitUntil(timeout: .seconds(5), action: { (done) in
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -218,7 +218,7 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                                         fail()
                                     }
                                 } receiveValue: { values in
-                                    expect(values.0.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                    expect(values.0.products.count).to(beGreaterThan(0))
                                     done()
                                 }
                                 .store(in: &cancellables)
@@ -226,13 +226,13 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                     }
 
                     it("should receive values from both layers even if nothing (empty array) is returned from the persistence layer") {
-                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+                        Given(network, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
 
                         Given(persistence, .fetchResource(
                             .any,
                             willReturn: {
-                                let publisher = CurrentValueSubject<BabyNamePopularityDataContainer, PersistenceLayerError>(.init(data: []))
-                                publisher.send(.init(data: []))
+                                let publisher = CurrentValueSubject<DummyProductDataContainer, PersistenceLayerError>(.stub())
+                                publisher.send(.stub())
                                 return publisher.eraseToAnyPublisher()
                             }()
                         ))
@@ -240,10 +240,10 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                         Given(network, .fetchData( request: .any, willReturn: {
                             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
-                            let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
+                            let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
                             var data: Data? = nil
                             do {
-                                let jsonData = try JSONEncoder().encode(babyNamePopularities)
+                                let jsonData = try JSONEncoder().encode(dataContainer)
                                 data = jsonData
                             } catch { }
 
@@ -261,7 +261,7 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                             var invocationsCount = 0;
                             
                             dataProvider
-                                .fetchStuff(resource: .babyNamePopularities)
+                                .fetchStuff(resource: .dummyProductsAll)
                                 .sink { completion in
                                     switch completion {
                                     case .finished:
@@ -274,9 +274,9 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
 
                                     switch source {
                                     case .local:
-                                        expect(value.babyNamePopularityRepresentation.count).to(equal(0))
+                                        expect(value.products.count).to(equal(0))
                                     case .remote:
-                                        expect(value.babyNamePopularityRepresentation.count).to(beGreaterThan(0))
+                                        expect(value.products.count).to(beGreaterThan(0))
                                     }
 
                                     invocationsCount += 1;
@@ -290,5 +290,16 @@ class DataProviderRemoteThenLocalTests: QuickSpec {
                 }
             }
         }
+    }
+}
+
+private extension DummyProductDataContainer {
+    static func stub() -> DummyProductDataContainer {
+        .init(
+            total: 0,
+            skip: 0,
+            limit: 0,
+            products: []
+        )
     }
 }

--- a/IRShowcaseMVPTests/DataProvider/NetworkParserTests.swift
+++ b/IRShowcaseMVPTests/DataProvider/NetworkParserTests.swift
@@ -25,25 +25,25 @@ class NetworkParserTests: XCTestCase {
         let expectation = self.expectation(description: "Expected to decode/encode properly")
         defer { self.waitForExpectations(timeout: 1.0, handler: nil) }
 
-        let babyNamePopularities: BabyNamePopularityDataContainer = ReadFile.object(from: "babyNamePopularities", extension: "json")
-        XCTAssertTrue(babyNamePopularities.babyNamePopularityRepresentation.count > 0)
+        let dataContainer: DummyProductDataContainer = ReadFile.object(from: "dummyProductTestsBundleOnly", extension: "json", bundle: Bundle(for: DummyProductsListViewTests.self))
+        XCTAssertTrue(dataContainer.products.count > 0)
         var data: Data? = nil
 
         do {
-            let jsonData = try JSONEncoder().encode(babyNamePopularities)
+            let jsonData = try JSONEncoder().encode(dataContainer)
             data = jsonData
         } catch { XCTFail() }
 
         XCTAssertNotNil(data)
 
-        let dpHandlersBuilder = DataProviderHandlersBuilder<BabyNamePopularityDataContainer>()
+        let dpHandlersBuilder = DataProviderHandlersBuilder<DummyProductDataContainer>()
         let networkParser = dpHandlersBuilder.standardNetworkParserHandler
 
         networkParser(data!)
             .sink { completion in
                 // do nothing
-            } receiveValue: { babyNames in
-                XCTAssertTrue(babyNames.babyNamePopularityRepresentation.count == babyNamePopularities.babyNamePopularityRepresentation.count)
+            } receiveValue: { values in
+                XCTAssertTrue(values.products.count == dataContainer.products.count)
                 expectation.fulfill()
             }
             .store(in: &cancellables)
@@ -54,7 +54,7 @@ class NetworkParserTests: XCTestCase {
         defer { self.waitForExpectations(timeout: 3.0, handler: nil) }
 
         let data: Data? = NSData() as Data
-        let dpHandlersBuilder = DataProviderHandlersBuilder<[BabyNamePopularity]>()
+        let dpHandlersBuilder = DataProviderHandlersBuilder<DummyProductDataContainer>()
         let networkParser = dpHandlersBuilder.standardNetworkParserHandler
 
         networkParser(data!)

--- a/IRShowcaseMVPTests/DataProvider/NetworkTests.swift
+++ b/IRShowcaseMVPTests/DataProvider/NetworkTests.swift
@@ -16,13 +16,13 @@ import Combine
 class NetworkTests: XCTestCase {
     private var cancellables: Set<AnyCancellable>!
     private var network: APIServiceMock!
-    private var networkHandler: DataProviderHandlers<[BabyNamePopularity]>.NetworkHandler!
+    private var networkHandler: DataProviderHandlers<DummyProductDataContainer>.NetworkHandler!
 
     override func setUp() {
         super.setUp()
         cancellables = Set<AnyCancellable>()
         network = APIServiceMock()
-        let dpHandlersBuilder = DataProviderHandlersBuilder<[BabyNamePopularity]>()
+        let dpHandlersBuilder = DataProviderHandlersBuilder<DummyProductDataContainer>()
         networkHandler = dpHandlersBuilder.standardNetworkHandler
     }
 
@@ -38,7 +38,7 @@ class NetworkTests: XCTestCase {
 
         Given(
             network,
-            .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!))
+            .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!))
         )
 
         Given(
@@ -49,7 +49,7 @@ class NetworkTests: XCTestCase {
             )
         )
 
-        networkHandler(network,network.buildUrlRequest(resource: .unknown))
+        networkHandler(network,network.buildUrlRequest(resource: .dummyProductsAll))
                 .sink { completion in
                     XCTFail()
                 } receiveValue: { babyNames in
@@ -64,7 +64,7 @@ class NetworkTests: XCTestCase {
 
         Given(
             network,
-            .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!))
+            .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!))
         )
 
         let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
@@ -77,7 +77,7 @@ class NetworkTests: XCTestCase {
             )
         )
 
-        networkHandler(network,network.buildUrlRequest(resource: .unknown))
+        networkHandler(network,network.buildUrlRequest(resource: .dummyProductsAll))
                 .sink { completion in
                     expectation.fulfill()
                 } receiveValue: { babyNames in

--- a/IRShowcaseMVPTests/DataProvider/ResourceTests.swift
+++ b/IRShowcaseMVPTests/DataProvider/ResourceTests.swift
@@ -13,14 +13,14 @@ import XCTest
 
 class ResourceTests: XCTestCase {
     func testEqualityForSameResource() {
-        let resource1 = Resource.babyNamePopularities
-        let resource2 = Resource.babyNamePopularities
+        let resource1 = Resource.dummyProductsAll
+        let resource2 = Resource.dummyProductsAll
         XCTAssertEqual(resource1, resource2)
     }
 
     func testInequalityForDifferentResource() {
         let resource1 = Resource.unknown
-        let resource2 = Resource.babyNamePopularities
+        let resource2 = Resource.dummyProductsAll
         XCTAssertNotEqual(resource1, resource2)
         XCTAssertNotEqual(resource2, resource1)
     }

--- a/IRShowcaseMVPTests/ViewModels/DummyProductsWithHybridDataProviderViewModelTests.swift
+++ b/IRShowcaseMVPTests/ViewModels/DummyProductsWithHybridDataProviderViewModelTests.swift
@@ -48,7 +48,7 @@ final class DummyProductsWithHybridDataProviderViewModelTests: TestCase {
         }()
         ))
 
-        Given(networkMock, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+        Given(networkMock, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
         Given(networkMock, .fetchData( request: .any, willReturn: {
             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
 
@@ -120,7 +120,7 @@ final class DummyProductsWithHybridDataProviderViewModelTests: TestCase {
         }()
         ))
 
-        Given(networkMock, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+        Given(networkMock, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
         Given(networkMock, .fetchData( request: .any, willReturn: {
             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
             publisher.send(completion: .failure(DataProviderError.noConnectivity))
@@ -178,7 +178,7 @@ final class DummyProductsWithHybridDataProviderViewModelTests: TestCase {
         }()
         ))
 
-        Given(networkMock, .buildUrlRequest(resource: .any, willReturn: Resource.babyNamePopularities.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
+        Given(networkMock, .buildUrlRequest(resource: .any, willReturn: Resource.dummyProductsAll.buildUrlRequest(apiBaseUrl: URL(string: "https://fake.com")!)))
         Given(networkMock, .fetchData( request: .any, willReturn: {
             let publisher = CurrentValueSubject<(Data, URLResponse), DataProviderError>((Data(), URLResponse()))
             publisher.send(completion: .failure(DataProviderError.noConnectivity))

--- a/README.md
+++ b/README.md
@@ -10,13 +10,18 @@ Follows the same project structure as [IRShowcase](https://github.com/iruleonu/I
 * SwiftUI
 * Combine
 
+## Architecture layers naming
+You can look at the ViewModel as the Interactor and the ObservableObject within the ViewModel as the Presenter. The view in SwiftUI sends actions to the ViewModel (the Interactor layer) and reads the State from the ObservableObject within the ViewModel (the Presenter layer)
+
 ## Misc
 * It has a ObservableObject that's going to be connected to the SwiftUI view as a @ObservedObject, essentially serving as a State. The viewModel has the logic.
 
-* On RootCoordinatorBuilder you'll see it injects the two layers (APIService and Persistence) into the main screen presenter (DummyProductsViewPresenterImpl)
+* FooViewModel is a protocol that's marked with "// sourcery: AutoMockable" so that it can be mocked in the tests. The implementation goes into FooViewModelImpl.
+
+* On RootCoordinatorBuilder you'll see it injects the two layers (APIService and Persistence) into the main screen presenter (DummyProductsViewViewModelImpl)
 On the same RootCoordinatorBuilder there's a second entry point where you can see an example with two DataProviders that can be used with a distinct configuration. 
 It's possible to make it a hybrid data provider where it fetches both locally and remotely in case of a local fetch error.
 
 * There's tests for logic, providers and UI tests.
 
-* DummyProductsListViewPresenterTests has tests making sure if there's valid results locally then there's no remote fetch
+* DummyProductsListViewModelTests has tests making sure if there's valid results locally then there's no remote fetch


### PR DESCRIPTION
Replace the "BabyNames" with the "DummyProduct" in the data provider tests.
Uptated readme.